### PR TITLE
Update Node.js to a supported version in `release.yml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,6 @@ jobs:
           - dotnet
           - go
         nodeversion:
-          - 14.x
+          - 20.x
         pythonversion:
           - "3.9"


### PR DESCRIPTION
Currently the `.github/workflows/release.yml` file from the Pulumi boilerplate is configured to use Node.js `v14`, which as of this writing in 2024 is outdated and unsupported. This PR updates Node.js to `v20`, which is the current LTS version.