### PR TITLE
FIX: Build SDKs issue in cicd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,18 +82,18 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
-          registry-url: ${{env.NPM_REGISTRY_URL}}
+          node-version: ${{ matrix.nodeversion }}
+          registry-url: ${{ env.NPM_REGISTRY_URL }}
 
       - name: Setup DotNet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{matrix.dotnetverson}}
+          dotnet-version: ${{ matrix.dotnetverson }}
 
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: ${{matrix.pythonversion}}
+          python-version: ${{ matrix.pythonversion }}
 
       - name: Build SDK
         run: make build_${{ matrix.language }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,75 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish_binary
     steps:
-      - name: Publish SDKs
-        uses: pulumi/pulumi-package-publisher@v0.0.14
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.goversion }}
+
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        with:
+          repo: pulumi/pulumictl
+
+      - name: Install pulumi
+        uses: pulumi/actions@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{matrix.nodeversion}}
+          registry-url: ${{env.NPM_REGISTRY_URL}}
+
+      - name: Setup DotNet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{matrix.dotnetverson}}
+
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{matrix.pythonversion}}
+
+      - name: Build SDK
+        run: make build_${{ matrix.language }}
+
+      - name: Check worktree clean
+        run: |
+          git update-index -q --refresh
+          if ! git diff-files --quiet; then
+              >&2 echo "error: working tree is not clean, aborting!"
+              git status
+              git diff
+              exit 1
+          fi
+
+      - if: ${{ matrix.language == 'python' && env.PUBLISH_PYPI == 'true' }}
+        name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: ${{ env.PYPI_USERNAME }}
+          password: ${{ env.PYPI_PASSWORD }}
+          packages_dir: ${{github.workspace}}/sdk/python/bin/dist
+
+      - if: ${{ matrix.language == 'nodejs' && env.PUBLISH_NPM == 'true' }}
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          access: "public"
+          token: ${{ env.NPM_TOKEN }}
+          package: ${{github.workspace}}/sdk/nodejs/bin/package.json
+
+      - if: ${{ matrix.language == 'dotnet' && env.PUBLISH_NUGET == 'true' }}
+        name: publish nuget package
+        run: |
+          dotnet nuget push ${{github.workspace}}/sdk/dotnet/bin/Debug/*.nupkg -s ${{ env.NUGET_FEED_URL }} -k ${{ env.NUGET_PUBLISH_KEY }}
+          echo "done publishing packages"
+
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
The boilerplate instructed us to use this [release.yml](https://github.com/pulumi/pulumi-tf-provider-boilerplate/blob/main/deployment-templates/release.yml) file to publish. However, this yaml does not contain a step to build the SDKs before publishing - resulting in _artifact not found_ errors.

This is a PR to fix this issue by rewriting the release.yml to explicitly contain these steps. Resources I used to get started are here:
- https://github.com/tmeckel/pulumi-tf-provider-cookiecutter/blob/master/%7B%7Bcookiecutter.provider%7D%7D/.github/workflows/release.yml#L126
- https://github.com/csechrist/pulumi-airbyte/commit/1fb546f4ec2bead3f74cd99aff3f8d829ab62cac