### PR TITLE
Convert action inputs to use kebab-case for PyPi publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
         with:
           user: ${{ env.PYPI_USERNAME }}
           password: ${{ env.PYPI_PASSWORD }}
-          packages_dir: ${{github.workspace}}/sdk/python/bin/dist
+          packages-dir: ${{github.workspace}}/sdk/python/bin/dist
 
       - if: ${{ matrix.language == 'nodejs' && env.PUBLISH_NPM == 'true' }}
         uses: JS-DevTools/npm-publish@v1


### PR DESCRIPTION
In our release workflow, PyPi gives us a warning because of a deprecated input `packages_dir`. I've followed the recommendation and changed the input to follow kebab-case (i.e. `packages-dir`).
![Screenshot 2024-05-14 at 1 39 15 PM](https://github.com/1Password/pulumi-onepassword/assets/55631417/bcef1794-024a-489e-bad7-6859d397943b)

For completion's sake, I looked into the [PR that made this change](https://github.com/pypa/gh-action-pypi-publish/pull/125) in the pypi-publish action. This was merged as of [v1.7.0](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.7.0). We use the latest version hence we see this message.