### PR TITLE
upgrade-provider GitHub Actions workflow

### DIFF
--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -1,0 +1,25 @@
+name: Upgrade bridge
+
+on:
+  workflow_dispatch:
+  schedule:
+    # At 05:00 on Monday
+    - cron: 0 5 * * 1
+
+jobs:
+  upgrade_bridge:
+    name: upgrade-bridge
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Call upgrade provider action
+        uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
+        with:
+          kind: bridge
+          email: ringo@de-smet.name
+          username: "Ringo De Smet"
+        env:
+          GH_TOKEN: ${{ secrets.UPGRADE_PROVIDER_TOKEN }}

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -3,8 +3,8 @@ name: upgrade_provider
 on:
   workflow_dispatch:
   schedule:
-    # https://crontab.guru/#0_16_*_*_WED = "At 16:00 (UTC) on Wednesday."
-    - cron: 0 16 * * WED
+    # https://crontab.guru/#0_20_*_*_WED = "At 20:00 (UTC) on Wednesday."
+    - cron: 0 20 * * WED
 
 jobs:
   upgrade_provider:

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -17,8 +17,5 @@ jobs:
     steps:
       - name: Call upgrade provider action
         uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
-        with:
-          email: ringo@de-smet.name
-          username: "Ringo De Smet"
         env:
           GH_TOKEN: ${{ secrets.UPGRADE_PROVIDER_TOKEN }}

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -3,8 +3,8 @@ name: upgrade_provider
 on:
   workflow_dispatch:
   schedule:
-    # https://crontab.guru/#0_20_*_*_TUE = "At 20:00 (UTC) on Tuesday."
-    - cron: 0 20 * * TUE
+    # https://crontab.guru/#0_16_*_*_WED = "At 16:00 (UTC) on Wednesday."
+    - cron: 0 16 * * WED
 
 jobs:
   upgrade_provider:

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -1,4 +1,4 @@
-name: Upgrade bridge
+name: upgrade_provider
 
 on:
   workflow_dispatch:
@@ -7,8 +7,8 @@ on:
     - cron: 0 5 * * 1
 
 jobs:
-  upgrade_bridge:
-    name: upgrade-bridge
+  upgrade_provider:
+    name: upgrade_provider
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Call upgrade provider action
         uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
         with:
-          kind: bridge
           email: ringo@de-smet.name
           username: "Ringo De Smet"
         env:

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -3,8 +3,8 @@ name: upgrade_provider
 on:
   workflow_dispatch:
   schedule:
-    # At 05:00 on Monday
-    - cron: 0 5 * * 1
+    # https://crontab.guru/#0_20_*_*_TUE = "At 20:00 (UTC) on Tuesday."
+    - cron: 0 20 * * TUE
 
 jobs:
   upgrade_provider:

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Call upgrade provider action
         uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
         env:
-          GH_TOKEN: ${{ secrets.UPGRADE_PROVIDER_TOKEN }}
+          GH_TOKEN: ${{ secrets.PULUMI_1P_UPGRADE_PROVIDER_GH_TOKEN }}


### PR DESCRIPTION
- This PR addresses the final "Upgrade" section of the https://github.com/pulumi/pulumi-tf-provider-boilerplate/blob/main/deployment-templates/README-DEPLOYMENT.md documentation.
- More specifically and as advised by @ringods, this workflow file uses https://github.com/pulumiverse/pulumi-acme/blob/main/.github/workflows/upgrade-bridge.yml as a template.
- This workflow should run according to the defined `cron` schedule (note that this schedule may be modified in future commits), and if successful it should produce an auto-upgrade PR for this pulumi-onepassword bridge provider if it finds upstream changes from the [terraform-provider-onepassword](https://github.com/1Password/terraform-provider-onepassword) repo.