### PR TITLE
Initial '.upgrade-config.yml' configuration file

### DIFF
--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -3,8 +3,8 @@ name: upgrade_provider
 on:
   workflow_dispatch:
   schedule:
-    # https://crontab.guru/#0_20_*_*_WED = "At 20:00 (UTC) on Wednesday."
-    - cron: 0 20 * * WED
+    # https://crontab.guru/#45_18_*_*_THU = "At 18:45 (UTC) on Thursday."
+    - cron: 45 18 * * THU
 
 jobs:
   upgrade_provider:

--- a/.upgrade-config.yml
+++ b/.upgrade-config.yml
@@ -1,0 +1,4 @@
+# Upstream provider links:
+# - GitHub repo: https://github.com/1Password/terraform-provider-onepassword
+# - Terraform registry: https://registry.terraform.io/providers/1Password/onepassword
+upstream-provider-name: terraform-provider-onepassword


### PR DESCRIPTION
- The most recent [upgrade_provider](https://github.com/1Password/pulumi-onepassword/actions/runs/9197659098/job/25298621670#step:2:624) run failed with the `Error: upstream-provider-name must be provided` error message.
- This PR addresses this error by referencing an example found in [pulumiverse/pulumi-acme/.upgrade-config.yml](https://github.com/pulumiverse/pulumi-acme/blob/main/.upgrade-config.yml), and in this case `upstream-provider-name` is set to `terraform-provider-onepassword`.