### PR TITLE
fix(release.yml): exclude 'sdk/nodejs/getVault.ts' from Git diff check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,8 @@ jobs:
           git update-index -q --refresh
           if ! git diff-files --quiet \
             ':(exclude)provider/cmd/pulumi-resource-onepassword/schema.json' \
-            ':(exclude)sdk/nodejs/getItem.ts'; then
+            ':(exclude)sdk/nodejs/getItem.ts' \
+            ':(exclude)sdk/nodejs/getVault.ts'; then
               >&2 echo "error: working tree is not clean, aborting!"
               git status
               git diff


### PR DESCRIPTION
- This PR is a workaround for the issue described in [this](https://github.com/pulumi/pulumi/issues/15979) codegen bug.
- Should resolve [this](https://github.com/1Password/pulumi-onepassword/actions/runs/9390341259/job/25860141778#step:12:34) job failure.