### PR TITLE
Add documentation for Pulumi registry

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -4,8 +4,8 @@ meta_desc: Provides an overview of the 1Password Provider for Pulumi.
 layout: package
 ---
 
-The Aiven provider for Pulumi can be used to provision any of the cloud resources available in [Aiven](https://aiven.io/).
-The Aiven provider must be configured with credentials to deploy and update resources in Aiven.
+The 1Password provider for Pulumi allows you to access and manage items in your [1Password](https://1password.com) vaults.
+You'll need to configure the 1Password provider with credentials to access and manage items in 1Password.
 
 ## Example
 
@@ -85,6 +85,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Pulumi;
 using Onepassword = Pulumi.Onepassword;
+
 return await Deployment.RunAsync(() =&gt; 
 {
     var example = Onepassword.GetItem.Invoke(new()
@@ -92,6 +93,7 @@ return await Deployment.RunAsync(() =&gt;
         Vault = data.Onepassword_vault.Example.Uuid,
         Uuid = onepassword_item.Demo_sections.Uuid,
     });
+
 });
 ```
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,0 +1,102 @@
+---
+title: 1Password
+meta_desc: Provides an overview of the 1Password Provider for Pulumi.
+layout: package
+---
+
+The Aiven provider for Pulumi can be used to provision any of the cloud resources available in [Aiven](https://aiven.io/).
+The Aiven provider must be configured with credentials to deploy and update resources in Aiven.
+
+## Example
+
+{{< chooser language "javascript,typescript,python,go" >}}
+
+{{% choosable language javascript %}}
+
+```javascript
+const pulumi = require("@pulumi/pulumi");
+const onepassword = require("@1password/pulumi-onepassword");
+
+const example = onepassword.getItem({
+    vault: data.onepassword_vault.example.uuid,
+    uuid: onepassword_item.demo_sections.uuid,
+});
+```
+
+{{% /choosable %}}
+{{% choosable language typescript %}}
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as onepassword from "@1password/pulumi-onepassword";
+
+const example = onepassword.getItem({
+    vault: data.onepassword_vault.example.uuid,
+    uuid: onepassword_item.demo_sections.uuid,
+});
+```
+
+{{% /choosable %}}
+{{% choosable language python %}}
+
+```python
+import pulumi
+import pulumi_onepassword as onepassword
+
+example = onepassword.get_item(vault=data["onepassword_vault"]["example"]["uuid"],
+    uuid=onepassword_item["demo_sections"]["uuid"])
+```
+
+{{% /choosable %}}
+{{% choosable language go %}}
+
+```go
+package main
+
+import (
+
+	"github.com/1Password/pulumi-onepassword/sdk/go/onepassword"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := onepassword.LookupItem(ctx, &onepassword.LookupItemArgs{
+			Vault: data.Onepassword_vault.Example.Uuid,
+			Uuid:  pulumi.StringRef(onepassword_item.Demo_sections.Uuid),
+		}, nil)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+```
+
+{{% /choosable %}}
+
+<!--
+
+{{% choosable language csharp %}}
+
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using Onepassword = Pulumi.Onepassword;
+return await Deployment.RunAsync(() =&gt; 
+{
+    var example = Onepassword.GetItem.Invoke(new()
+    {
+        Vault = data.Onepassword_vault.Example.Uuid,
+        Uuid = onepassword_item.Demo_sections.Uuid,
+    });
+});
+```
+
+{{% /choosable %}}
+
+-->
+
+{{< /chooser >}}

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -15,17 +15,17 @@ The 1Password provider for Pulumi is available as a package in most Pulumi langu
 - Go: [github.com/1Password/pulumi-onepassword/sdk/go/onepassword](https://pkg.go.dev/github.com/1Password/pulumi-onepassword/sdk/go/onepassword)
 - .NET: _coming soon_
 
-## Configuring Credentials
+## Configuration
 
 You must configure the 1Password provider for Pulumi with your 1Password credentials before the provider can be used to access and manage items in your 1Password vaults. You can use one of the following:
 
 - [Service account](https://developer.1password.com/docs/service-accounts/get-started)
-  - `pulumi-onepassword:service_account_token` (environment: `OP_SERVICE_ACCOUNT_TOKEN`) - the 1Password service account token to use with 1Password CLI.
+  - `pulumi-onepassword:service_account_token` (environment: `OP_SERVICE_ACCOUNT_TOKEN`) - the 1Password service account token. Requires [1Password CLI](https://developer.1password.com/docs/cli/get-started/).
 - [Connect server](https://developer.1password.com/docs/connect/get-started)
   - `pulumi-onepassword:url` (environment: `OP_CONNECT_HOST`) - the URL where your 1Password Connect API can be found.
   - `pulumi-onepassword:token` (environment: `OP_CONNECT_TOKEN`) - the token for your Connect API.
 - Personal account
-  - `pulumi-onepassword:account` (environment: `OP_ACCOUNT`) - the [sign-in address](https://support.1password.com/1password-glossary/#sign-in-address) or [unique identifier](https://developer.1password.com/docs/cli/reference/#unique-identifiers-ids) for your 1Password account to use with 1Password CLI and biometric unlock.
+  - `pulumi-onepassword:account` (environment: `OP_ACCOUNT`) - the [sign-in address](https://support.1password.com/1password-glossary/#sign-in-address) or [unique identifier](https://developer.1password.com/docs/cli/reference/#unique-identifiers-ids) for your 1Password account to use. Requires [1Password CLI](https://developer.1password.com/docs/cli/get-started/) and biometric unlock.
 
 After you find your credentials, there are two ways to provide them to Pulumi:
 

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -1,14 +1,14 @@
 ---
 title: 1Password: Installation & Configuration
-meta_desc: Provides an overview on how to configure credentials for the 1Password Pulumi Provider.
+meta_desc: Provides an overview on how to configure credentials for the 1Password provider for Pulumi.
 layout: package
 ---
 
-The 1Password Pulumi provider enables accessing and managing items in your 1Password vaults.
+The 1Password provider for Pulumi allows you to access and manage items in your 1Password vaults using Pulumi.
 
 ## Installation
 
-The 1Password Pulumi provider is available as a package in most Pulumi languages:
+The 1Password provider for Pulumi is available as a package in most Pulumi languages:
 
 - JavaScript/TypeScript: [@1password/pulumi-onepassword](https://www.npmjs.com/package/@1password/pulumi-onepassword)
 - Python: [pulumi_onepassword](https://pypi.org/project/pulumi-onepassword/)
@@ -17,28 +17,28 @@ The 1Password Pulumi provider is available as a package in most Pulumi languages
 
 ## Configuring Credentials
 
-The 1Password pulumi provider needs to be configured with 1Password credentials before it can be used to access and manage items in your 1Password vault. You can configure it to use one of the following:
+You must configure the 1Password provider for Pulumi with your 1Password credentials before the provider can be used to access and manage items in your 1Password vaults. You can use one of the following:
 
-- Service account
-  - `pulumi-onepassword:service_account_token` (environment: `OP_SERVICE_ACCOUNT_TOKEN`) - The 1Password service account token to use with 1Password CLI.
-- Connect
+- [Service account](https://developer.1password.com/docs/service-accounts/get-started)
+  - `pulumi-onepassword:service_account_token` (environment: `OP_SERVICE_ACCOUNT_TOKEN`) - the 1Password service account token to use with 1Password CLI.
+- [Connect server](https://developer.1password.com/docs/connect/get-started)
   - `pulumi-onepassword:url` (environment: `OP_CONNECT_HOST`) - the URL where your 1Password Connect API can be found.
   - `pulumi-onepassword:token` (environment: `OP_CONNECT_TOKEN`) - the token for your Connect API.
 - Personal account
-  - `pulumi-onepassword:account` (environment: `OP_ACCOUNT`) - A valid account's sign-in address or ID to use with 1Password CLI and biometric unlock.
+  - `pulumi-onepassword:account` (environment: `OP_ACCOUNT`) - the [sign-in address](https://support.1password.com/1password-glossary/#sign-in-address) or [unique identifier](https://developer.1password.com/docs/cli/reference/#unique-identifiers-ids) for your 1Password account to use with 1Password CLI and biometric unlock.
 
-Once the credentials obtained, there are two ways to communicate your configuration to Pulumi:
+After you find your credentials, there are two ways to provide them to Pulumi:
 
-1. Set the environment variables for the preferred method:
+1. Set the environment variables for the preferred method. For example, to set the environment variable for a service account token:
 
    ```sh
    $ export OP_SERVICE_ACCOUNT_TOKEN=XXXXXXXXXXXXXX
    ```
 
-2. Set them using configuration, if you prefer that they be stored alongside your Pulumi stack for easy multi-user access:
+2. If you prefer to store your credentials alongside your Pulumi stack for easy multi-user access, use configuration to set them.
 
    ```sh
    $ pulumi config set pulumi-onepassword:service_account_token XXXXXXXXXXXXXX --secret
    ```
 
-Remember to pass `--secret` when setting any sensitive data (in this example `pulumi-onepassword:service_account_token`) so that it is properly encrypted. The complete list of configuration parameters is in the [1Password Pulumi provider README](https://github.com/1Password/pulumi-onepassword/blob/main/README.md).
+Make sure to pass `--secret` when setting any sensitive data (in this example `pulumi-onepassword:service_account_token`) so that it's properly encrypted. The complete list of configuration parameters is in the [1Password provider for Pulumi README](https://github.com/1Password/pulumi-onepassword/blob/main/README.md).

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -1,0 +1,44 @@
+---
+title: 1Password: Installation & Configuration
+meta_desc: Provides an overview on how to configure credentials for the 1Password Pulumi Provider.
+layout: package
+---
+
+The 1Password Pulumi provider enables accessing and managing items in your 1Password vaults.
+
+## Installation
+
+The 1Password Pulumi provider is available as a package in most Pulumi languages:
+
+- JavaScript/TypeScript: [@1password/pulumi-onepassword](https://www.npmjs.com/package/@1password/pulumi-onepassword)
+- Python: [pulumi_onepassword](https://pypi.org/project/pulumi-onepassword/)
+- Go: [github.com/1Password/pulumi-onepassword/sdk/go/onepassword](https://pkg.go.dev/github.com/1Password/pulumi-onepassword/sdk/go/onepassword)
+- .NET: _coming soon_
+
+## Configuring Credentials
+
+The 1Password pulumi provider needs to be configured with 1Password credentials before it can be used to access and manage items in your 1Password vault. You can configure it to use one of the following:
+
+- Service account
+  - `pulumi-onepassword:service_account_token` (environment: `OP_SERVICE_ACCOUNT_TOKEN`) - The 1Password service account token to use with 1Password CLI.
+- Connect
+  - `pulumi-onepassword:url` (environment: `OP_CONNECT_HOST`) - the URL where your 1Password Connect API can be found.
+  - `pulumi-onepassword:token` (environment: `OP_CONNECT_TOKEN`) - the token for your Connect API.
+- Personal account
+  - `pulumi-onepassword:account` (environment: `OP_ACCOUNT`) - A valid account's sign-in address or ID to use with 1Password CLI and biometric unlock.
+
+Once the credentials obtained, there are two ways to communicate your configuration to Pulumi:
+
+1. Set the environment variables for the preferred method:
+
+   ```sh
+   $ export OP_SERVICE_ACCOUNT_TOKEN=XXXXXXXXXXXXXX
+   ```
+
+2. Set them using configuration, if you prefer that they be stored alongside your Pulumi stack for easy multi-user access:
+
+   ```sh
+   $ pulumi config set pulumi-onepassword:service_account_token XXXXXXXXXXXXXX --secret
+   ```
+
+Remember to pass `--secret` when setting any sensitive data (in this example `pulumi-onepassword:service_account_token`) so that it is properly encrypted. The complete list of configuration parameters is in the [1Password Pulumi provider README](https://github.com/1Password/pulumi-onepassword/blob/main/README.md).

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -25,7 +25,7 @@ You must configure the 1Password provider for Pulumi with your 1Password credent
   - `pulumi-onepassword:url` (environment: `OP_CONNECT_HOST`) - the URL where your 1Password Connect API can be found.
   - `pulumi-onepassword:token` (environment: `OP_CONNECT_TOKEN`) - the token for your Connect API.
 - Personal account
-  - `pulumi-onepassword:account` (environment: `OP_ACCOUNT`) - the [sign-in address](https://support.1password.com/1password-glossary/#sign-in-address) or [unique identifier](https://developer.1password.com/docs/cli/reference/#unique-identifiers-ids) for your 1Password account to use. Requires [1Password CLI](https://developer.1password.com/docs/cli/get-started/) and biometric unlock.
+  - `pulumi-onepassword:account` (environment: `OP_ACCOUNT`) - the [sign-in address](https://support.1password.com/1password-glossary/#sign-in-address) or [unique identifier](https://developer.1password.com/docs/cli/reference/#unique-identifiers-ids) for your 1Password account. Requires [1Password CLI](https://developer.1password.com/docs/cli/get-started/) and biometric unlock.
 
 After you find your credentials, there are two ways to provide them to Pulumi:
 


### PR DESCRIPTION
## Summary

This documentation will be used in the https://www.pulumi.com/registry website.

This was added according to the instructions mentioned in [Author packages in Pulumi Registry: Publish the documentation](https://www.pulumi.com/docs/using-pulumi/pulumi-packages/how-to-author/#publish-the-documentation).

The pages added are as follows:
- `_index.md` - Represents the overview page of the provider with example snippets for the available SDKs. The snippets have been extracted from the generated examples found in each SDK:
  - Go: `sdk/go/onepassword/getItem.go` L16-41
  - Javascript/Typescript: `sdk/nodejs/getItem.ts` L12-22
  - Python: `sdk/python/pulumi_onepassword/get_item.py` L221-229
  
   Check [Exoscale provider](https://www.pulumi.com/registry/packages/exoscale/) as an example.
- `installation-configuration.md` - Contains the following:
  - Installation: Contains links to the available SDKs
  - Credential configuration: The credential needed to authenticate the provider
 
  Check [Aiven](https://www.pulumi.com/registry/packages/aiven/installation-configuration/) and [Exoscale](https://www.pulumi.com/registry/packages/exoscale/installation-configuration/) providers as examples.

## Notes for reviewers

- [ ] Check if the example snippets match the ones generated in the SDK comments.
- [ ] Check if the `Installation and configuration` contains the minimum documentation needed to get things started. Check the [README](https://github.com/1Password/pulumi-onepassword/blob/main/README.md) for additional details.
