### PR TITLE
Update GitHub Actions' versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         # The versions of golangci-lint and setup-go here cross-depend and need to update together.
         go-version: 1.21
@@ -37,8 +37,7 @@ jobs:
       run: make upstream
     - run: cd provider && go mod tidy
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v6
       with:
         version: v1.54.1
         working-directory: provider
-        skip-pkg-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,37 +61,37 @@ jobs:
     needs: publish_binary
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
 
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.goversion }}
 
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        uses: jaxxstorm/action-install-gh-release@v1
         with:
           repo: pulumi/pulumictl
 
       - name: Install pulumi
-        uses: pulumi/actions@v4
+        uses: pulumi/actions@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.nodeversion }}
           registry-url: ${{ env.NPM_REGISTRY_URL }}
 
       - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ matrix.dotnetverson }}
 
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.pythonversion }}
 
@@ -125,7 +125,7 @@ jobs:
 
       - if: ${{ matrix.language == 'nodejs' && env.PUBLISH_NPM == 'true' }}
         name: Publish to NPM
-        uses: JS-DevTools/npm-publish@v1
+        uses: JS-DevTools/npm-publish@v3
         with:
           access: "public"
           token: ${{ env.NPM_TOKEN }}


### PR DESCRIPTION
This PR updates the following GitHub Actions' versions:
- `actions/checkout` to `v4`
- `pulumi/actions` to `v5`
- `golangci/golangci-lint-action` to `v6`
- `actions/setup-go` to `v5`
- `actions/setup-node` to `v4`
- `actions/setup-dotnet` to `v4`
- `actions/setup-python` to `v5`
- `JS-DevTools/npm-publish` to `v3`

All these updated have been checked and no breaking changes directly impact our pipeline configuration. With this, we use the latest version of Node 20 in all actions, which is the recommended version.

The only one that isn't updated is `goreleaser/goreleaser-action` from `v5` to `v6` since this switches from `goreleaser` `v1` to `v2`. This requires some additional effort.