### PR TITLE
Fix configuration installation docs format

### DIFF
--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -1,5 +1,5 @@
 ---
-title: 1Password: Installation & Configuration
+title: 1Password Provider Installation & Configuration
 meta_desc: Provides an overview on how to configure credentials for the 1Password provider for Pulumi.
 layout: package
 ---


### PR DESCRIPTION
The installation configuration docs were having a restricted character in the title section. GitHub was complaining about it:
<img width="852" alt="Screenshot 2024-09-04 at 17 01 53" src="https://github.com/user-attachments/assets/643fda82-339b-44bf-b912-4d695630a516">

And it also caused problems when Pulumi attempted to publish our package's metadata: https://github.com/pulumi/registry/actions/runs/10689416368/job/29631474410#step:8:29

This PR fixes that.