### PR TITLE
Fix link to Pulumi registry in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ The following configuration points are available for the `1Password` provider:
 
 <!-- TODO: Confirm that this URL to the API documentation is correct. -->
 
-For detailed reference documentation, please visit [the Pulumi registry](https://www.pulumi.com/registry/packages/1Password/api-docs/).
+For detailed reference documentation, please visit [the Pulumi registry](https://www.pulumi.com/registry/packages/onepassword/).

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -67,4 +67,4 @@ The following configuration points are available for the `1Password` provider:
 
 <!-- TODO: Confirm that this URL to the API documentation is correct. -->
 
-For detailed reference documentation, please visit [the Pulumi registry](https://www.pulumi.com/registry/packages/1Password/api-docs/).
+For detailed reference documentation, please visit [the Pulumi registry](https://www.pulumi.com/registry/packages/onepassword/).


### PR DESCRIPTION
This MR fixes a 404ing link to the Pulumi registry.

Resolves https://github.com/1Password/pulumi-onepassword/issues/54