### PR TITLE
Fix: Update documentation from 'secureNote' to 'secure_note' for correct value

### DIFF
--- a/sdk/go/onepassword/item.go
+++ b/sdk/go/onepassword/item.go
@@ -68,7 +68,7 @@ import (
 type Item struct {
 	pulumi.CustomResourceState
 
-	// The category of the item. One of ["login" "password" "database" "secureNote"]
+	// The category of the item. One of ["login" "password" "database" "secure_note"]
 	Category pulumi.StringOutput `pulumi:"category"`
 	// (Only applies to the database category) The name of the database.
 	Database pulumi.StringPtrOutput `pulumi:"database"`
@@ -144,7 +144,7 @@ func GetItem(ctx *pulumi.Context,
 
 // Input properties used for looking up and filtering Item resources.
 type itemState struct {
-	// The category of the item. One of ["login" "password" "database" "secureNote"]
+	// The category of the item. One of ["login" "password" "database" "secure_note"]
 	Category *string `pulumi:"category"`
 	// (Only applies to the database category) The name of the database.
 	Database *string `pulumi:"database"`
@@ -177,7 +177,7 @@ type itemState struct {
 }
 
 type ItemState struct {
-	// The category of the item. One of ["login" "password" "database" "secureNote"]
+	// The category of the item. One of ["login" "password" "database" "secure_note"]
 	Category pulumi.StringPtrInput
 	// (Only applies to the database category) The name of the database.
 	Database pulumi.StringPtrInput
@@ -214,7 +214,7 @@ func (ItemState) ElementType() reflect.Type {
 }
 
 type itemArgs struct {
-	// The category of the item. One of ["login" "password" "database" "secureNote"]
+	// The category of the item. One of ["login" "password" "database" "secure_note"]
 	Category *string `pulumi:"category"`
 	// (Only applies to the database category) The name of the database.
 	Database *string `pulumi:"database"`
@@ -246,7 +246,7 @@ type itemArgs struct {
 
 // The set of arguments for constructing a Item resource.
 type ItemArgs struct {
-	// The category of the item. One of ["login" "password" "database" "secureNote"]
+	// The category of the item. One of ["login" "password" "database" "secure_note"]
 	Category pulumi.StringPtrInput
 	// (Only applies to the database category) The name of the database.
 	Database pulumi.StringPtrInput
@@ -363,7 +363,7 @@ func (o ItemOutput) ToItemOutputWithContext(ctx context.Context) ItemOutput {
 	return o
 }
 
-// The category of the item. One of ["login" "password" "database" "secureNote"]
+// The category of the item. One of ["login" "password" "database" "secure_note"]
 func (o ItemOutput) Category() pulumi.StringOutput {
 	return o.ApplyT(func(v *Item) pulumi.StringOutput { return v.Category }).(pulumi.StringOutput)
 }

--- a/sdk/nodejs/item.ts
+++ b/sdk/nodejs/item.ts
@@ -71,7 +71,7 @@ export class Item extends pulumi.CustomResource {
     }
 
     /**
-     * The category of the item. One of ["login" "password" "database" "secureNote"]
+     * The category of the item. One of ["login" "password" "database" "secure_note"]
      */
     public readonly category!: pulumi.Output<string>;
     /**
@@ -192,7 +192,7 @@ export class Item extends pulumi.CustomResource {
  */
 export interface ItemState {
     /**
-     * The category of the item. One of ["login" "password" "database" "secureNote"]
+     * The category of the item. One of ["login" "password" "database" "secure_note"]
      */
     category?: pulumi.Input<string>;
     /**
@@ -258,7 +258,7 @@ export interface ItemState {
  */
 export interface ItemArgs {
     /**
-     * The category of the item. One of ["login" "password" "database" "secureNote"]
+     * The category of the item. One of ["login" "password" "database" "secure_note"]
      */
     category?: pulumi.Input<string>;
     /**


### PR DESCRIPTION
## Description

This PR updates the documentation to correct the usage of 'secureNote' to 'secure_note'. The change ensures that the correct value is used, addressing an error encountered when implementing the repository in a Pulumi project.

Fixes Issue #59

## Problem

When following the existing documentation and using 'secureNote', an error occurred indicating that this value was not recognized. The correct value should be 'secure_note'.

## Solution

This PR updates all instances of 'secureNote' to 'secure_note' in the documentation, ensuring that users can implement the repository without encountering errors.

## Additional Notes

This correction is crucial for the proper implementation of the repository in Pulumi projects and will help prevent confusion for other users.

Related to Issue #59