### PR TITLE
fix(sdk/go): restore GetServiceAccountToken statement order

### DIFF
--- a/sdk/go/onepassword/config/config.go
+++ b/sdk/go/onepassword/config/config.go
@@ -41,8 +41,8 @@ func GetOpCliPath(ctx *pulumi.Context) string {
 // A valid 1Password service account token. Can also be sourced from `OP_SERVICE_ACCOUNT_TOKEN` environment variable.
 // Provider will use the 1Password CLI if set.
 func GetServiceAccountToken(ctx *pulumi.Context) string {
+	v, err := config.Try(ctx, "onepassword:serviceAccountToken")
 	if err == nil {
-		v, err := config.Try(ctx, "onepassword:serviceAccountToken")
 		return v
 	}
 	var value string


### PR DESCRIPTION
PR #61 inadvertently reordered the statements in GetServiceAccountToken, referencing err before it was declared. This broke compilation of the Go SDK config package on main (undefined: err). Restore the correct order.